### PR TITLE
Changes to improve compatability

### DIFF
--- a/src/main/engine/sm_ast_engine.c
+++ b/src/main/engine/sm_ast_engine.c
@@ -815,12 +815,12 @@ sm_object *sm_engine_eval(sm_object *input, sm_cx *current_cx, sm_expr *sf) {
         sm_expr_set_arg(output, 7, (sm_object *)sm_new_double(filestat.st_size));
         sm_expr_set_arg(output, 8, (sm_object *)sm_new_double(filestat.st_blksize));
         sm_expr_set_arg(output, 9, (sm_object *)sm_new_double(filestat.st_blocks));
-        sm_expr_set_arg(output, 10, (sm_object *)sm_new_double(filestat.st_atim.tv_sec));
-        sm_expr_set_arg(output, 11, (sm_object *)sm_new_double(filestat.st_atim.tv_nsec));
-        sm_expr_set_arg(output, 12, (sm_object *)sm_new_double(filestat.st_mtim.tv_sec));
-        sm_expr_set_arg(output, 13, (sm_object *)sm_new_double(filestat.st_mtim.tv_nsec));
-        sm_expr_set_arg(output, 14, (sm_object *)sm_new_double(filestat.st_ctim.tv_sec));
-        sm_expr_set_arg(output, 15, (sm_object *)sm_new_double(filestat.st_ctim.tv_nsec));
+        sm_expr_set_arg(output, 10, (sm_object *)sm_new_double(filestat.st_atime));
+        sm_expr_set_arg(output, 11, (sm_object *)sm_new_double(0));
+        sm_expr_set_arg(output, 12, (sm_object *)sm_new_double(filestat.st_mtime));
+        sm_expr_set_arg(output, 13, (sm_object *)sm_new_double(0));
+        sm_expr_set_arg(output, 14, (sm_object *)sm_new_double(filestat.st_ctime));
+        sm_expr_set_arg(output, 15, (sm_object *)sm_new_double(0));
       } else {
         printf("Failed to get file information.\n");
         return (sm_object *)sms_false;


### PR DESCRIPTION
Replaced references to st_ctim, st_atim, st_mtim and replaced with st_ctime, st_atime, st_mtime to get compiling on mac Ventura.

I believe there should be defines to handle conversion to the original usage if someone could test this on another system.

I also zeroed out the uses of tv_nsec since if I believe that files aren't tracked to the nanosecond level and they were causing issues for compilation due to the time/tim issue.